### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub fn input(prompt: &str) -> Option<String> {
         let rval = if rret != 0 as *mut i8 {
             let ptr = rret as *const i8;
             let cast = str::from_utf8(CStr::from_ptr(ptr).to_bytes()).unwrap().to_string();
+            libc::free(ptr as *mut libc::c_void);
             Some(cast)
         } else {
             None


### PR DESCRIPTION
linenoise() returns pointer to string allocated with strdup(). Its
ownership is passed to the caller which is responsible for deallocating
the string with free().

(see https://github.com/antirez/linenoise/blob/027dbcef5d6853897603763d39c1873449da2efe/example.c#L46)