### PR TITLE
Added runtime history access.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,7 @@ libc = "*"
 gcc = "*"
 
 [[bin]]
+# Build the example, but don't include it in documentation.
 name = "linenoise_example"
 path = "examples/linenoise_example.rs"
+doc = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ libc = "*"
 [build-dependencies]
 
 gcc = "*"
+
+[[bin]]
+name = "linenoise_example"
+path = "examples/linenoise_example.rs"

--- a/examples/linenoise_example.rs
+++ b/examples/linenoise_example.rs
@@ -16,7 +16,7 @@ fn main() {
     linenoise::set_multiline(0);
 
     loop {
-	    let val = linenoise::input("Hello\nDave -> ");
+	    let val = linenoise::input("Hello Dave -> ");
         match val {
             None => { break }
             Some(input) => {
@@ -25,7 +25,18 @@ fn main() {
 				let is: &str = input.as_ref();
                 if is == "clear" {
                 	linenoise::clear_screen();
-                }
+                } else if is == "history" {
+					let mut index = 0;
+					loop {
+						match linenoise::history_line(index) {
+							None => { break; },
+							Some(line) => {
+								println!("{}: {}", index, line);
+							}
+						};
+						index = index + 1;
+					}
+				}
             }
         }
     }

--- a/native/linenoise.c
+++ b/native/linenoise.c
@@ -1,5 +1,7 @@
-/* linenoise.c -- guerrilla line editing library against the idea that a
- * line editing lib needs to be 20,000 lines of C code.
+/* linenoise.c -- VERSION 1.0
+ *
+ * Guerrilla line editing library against the idea that a line editing lib
+ * needs to be 20,000 lines of C code.
  *
  * You can find the latest source code at:
  *
@@ -1066,6 +1068,14 @@ int linenoiseHistorySetMaxLen(int len) {
     if (history_len > history_max_len)
         history_len = history_max_len;
     return 1;
+}
+
+/* Fetch a line of the history by (zero-based) index.  If the requested
+ * line does not exist, NULL is returned.  The return value is a heap-allocated
+ * copy of the line, and the caller is responsible for de-allocating it. */
+char * linenoiseHistoryLine(const int index) {
+    if (index < 0 || index >= history_len) return NULL;
+    return strdup(history[index]);
 }
 
 /* Save the history in the specified file. On success 0 is returned

--- a/native/linenoise.h
+++ b/native/linenoise.h
@@ -1,5 +1,7 @@
-/* linenoise.h -- guerrilla line editing library against the idea that a
- * line editing lib needs to be 20,000 lines of C code.
+/* linenoise.h -- VERSION 1.0
+ *
+ * Guerrilla line editing library against the idea that a line editing lib
+ * needs to be 20,000 lines of C code.
  *
  * See linenoise.c for more information.
  *
@@ -63,6 +65,7 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 char *linenoise(const char *prompt);
+char *linenoiseHistoryLine(const int index);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1005,6 +1005,7 @@ extern "C" {
      -> libc::c_int;
     pub fn linenoiseHistoryLoad(filename: *const libc::c_char)
      -> libc::c_int;
+    pub fn linenoiseHistoryLine(index: libc::c_int) -> *mut libc::c_char;
     pub fn linenoiseClearScreen();
     pub fn linenoiseSetMultiLine(ml: libc::c_int);
     pub fn linenoisePrintKeyCodes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,22 @@ pub fn history_load(file: &str) -> i32 {
     ret
 }
 
+/// Get a line from the history by (zero-based) index
+pub fn history_line(index: i32) -> Option<String> {
+    unsafe {
+        let ret = ffi::linenoiseHistoryLine(index);
+        let rval = if ret != 0 as *mut i8 {
+            let ptr = ret as *const i8;
+            let cast = str::from_utf8(CStr::from_ptr(ptr).to_bytes()).unwrap().to_string();
+            libc::free(ptr as *mut libc::c_void);
+            Some(cast)
+        } else {
+            None
+        };
+        return rval;
+    }
+}
+
 ///Clears the screen
 pub fn clear_screen() {
     unsafe {


### PR DESCRIPTION
I added simple runtime history access to linenoise (pull req. 104 there) and mirrored through the FFI.  Added a history command to the example to show this off.  Removed newline from prompt, and added building of the example to `Cargo.toml`.