### PR TITLE
Update linenoise.cpp

### DIFF
--- a/native/linenoise.cpp
+++ b/native/linenoise.cpp
@@ -89,7 +89,7 @@
 #include <conio.h>
 #include <windows.h>
 #include <io.h>
-#if _MSC_VER < 1900
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf  // Microsoft headers use underscores in some names
 #endif
 #define strcasecmp _stricmp


### PR DESCRIPTION
I wasn't able to compile with mingw64 because snprintf was redefined...

I simply added a check, so that snprintf is only defined under MSVC. I suspect the default value for _MSC_VER to be 0 with mingw, and 0 < 1900.

I also PR'ed the original repo: https://github.com/arangodb/linenoise-ng/pull/5